### PR TITLE
added ‘new project’ and ‘new task’ workflows

### DIFF
--- a/protected/src/classes/Dashboard.php
+++ b/protected/src/classes/Dashboard.php
@@ -228,19 +228,28 @@ class Dashboard {
 			$f3->set('v_show_remove_members', $user->id === (int)$team['creator']);
 		}
 
-		// SET ADVANCED SEARCH LINK AND REFRESH LINK
+		// SET ADVANCED SEARCH LINK, REFRESH LINK, AND START NEW LINK
 		if($is_team) {
 			$f3->set('v_advanced_search_link', '/advanced-search?team='.$team['id']);
 			$f3->set('v_refresh_link', '/team/'.$team['id']);
+			$f3->set('v_start_new_link', sprintf('%s/team/%s?new', $f3->get('SITE_URL'), $team['id']));
 		} else {
 			$f3->set('v_advanced_search_link', '/advanced-search');
 			$f3->set('v_refresh_link', '/dashboard');
+			$f3->set('v_start_new_link', sprintf('%s/dashboard?new', $f3->get('SITE_URL')));
 		}
+
+		// SET VARIABLES FOR NEW PROJECT AND NEW TASK LINKS
+		$f3->set('v_new_project_link', sprintf('%s=project', $f3->get('v_start_new_link')));
+		$f3->set('v_new_task_link', sprintf('%s=task', $f3->get('v_start_new_link')));
 
 		// RENDER
 		$view = new \View;
 		if(isset($req['new'])) {
 			$f3->set('v_timer_start_new', true);
+			if($req['new'] === 'project' || $req['new'] === 'task') {
+				$f3->set('v_timer_start_new', $req['new']);
+			}
 		} else {
 			$f3->set('v_timer_start_new', false);
 		}

--- a/protected/templates/partials/timer.php
+++ b/protected/templates/partials/timer.php
@@ -25,6 +25,7 @@
 	<form action="<?php echo $SITE_URL; ?>/start-time" method="POST">
 		<input type="text" name="csrf" id="csrf_timer" value="<?php echo $CSRF; ?>" hidden>
 
+		<?php if($v_timer_start_new !== 'project'): ?>
 		<div class="form-group">
 			<label for="start_time_project">Project</label>
 			<select class="form-control" id="start_time_project" name="start_time_project"
@@ -38,8 +39,9 @@
 				<?php endforeach; ?>
 			</select>
 		</div>
+		<?php endif; ?>
 
-		<?php if($v_timer_start_new): ?>
+		<?php if($v_timer_start_new && $v_timer_start_new !== 'task'): ?>
 		<div class="form-group">
 			<label for="start_time_new_project">
 				Start New Project
@@ -49,6 +51,13 @@
 		</div>
 		<?php endif; ?>
 
+		<?php if(!$v_timer_start_new): ?>
+		<div class="form-group">
+			<p><a href="<?php echo $v_new_project_link; ?>">New Project</a></p>
+		</div>
+		<?php endif; ?>
+
+		<?php if($v_timer_start_new !== 'task'): ?>
 		<div class="form-group">
 			<label for="start_time_task">Task</label>
 			<select class="form-control" id="start_time_task" name="start_time_task"
@@ -62,6 +71,7 @@
 				<?php endforeach; ?>
 			</select>
 		</div>
+		<?php endif; ?>
 
 		<?php if($v_timer_start_new): ?>
 		<div class="form-group">
@@ -73,23 +83,11 @@
 		</div>
 		<?php endif; ?>
 
-		<?php
-		if(!$v_timer_start_new):
-			if($v_is_team):
-		?>
-		<div class="form-group text-center">
-			<p><a href="<?php echo $SITE_URL; ?>/team/<?php echo $v_team['id']; ?>?new">
-				Start New Project or Task
-			</a></p>
+		<?php if(!$v_timer_start_new): ?>
+		<div class="form-group">
+			<p><a href="<?php echo $v_new_task_link; ?>">New Task</a></p>
 		</div>
-		
-			<?php else: ?>
-		<div class="form-group text-center">
-			<p><a href="<?php echo $SITE_URL; ?>/dashboard?new">
-				Start New Project or Task
-			</a></p>
-		</div>
-		<?php endif; endif; ?>
+		<?php endif; ?>
 
 		<div class="form-group">
 			<label for="start_time_notes">Notes</label>
@@ -99,6 +97,9 @@
 
 		<div class="form-group">
 			<input class="btn btn-success" type="submit" value="Start" <?php echo $v_current_log ? 'disabled' : ' ' ?>>
+			<?php if($v_timer_start_new): ?>
+			<a href="<?php echo $v_refresh_link ?>" class="btn btn-link">Cancel</a>
+			<?php endif; ?>
 		</div>
 	</form>
 	<?php endif; ?>


### PR DESCRIPTION
Closes #40.

The goal of this implementation is to make the new project and task screens less intense by hiding inputs where it makes sense.