### PR TITLE
update url and csrf values after fragment swap

### DIFF
--- a/public/assets/js/controllers/fragment_loader_controller.js
+++ b/public/assets/js/controllers/fragment_loader_controller.js
@@ -27,11 +27,26 @@ export default class extends Controller {
         window.dispatchEvent(preSwapEvent);
 
         this.element.innerHTML = el.innerHTML;
+        window.history.pushState({}, '', url);
+        this.updateCSRF(temp);
 
         // post swap event
         const postSwapEvent = new CustomEvent('fragmentpostswap', {
             detail: id
         });
         window.dispatchEvent(postSwapEvent);
+    }
+
+    updateCSRF(responseBody) {
+        const csrfInput = responseBody.querySelector('[name="csrf"]');
+        if(!csrfInput) return;
+
+        const csrf = csrfInput.value;
+        const csrfInputs = Array.from(document.querySelectorAll('[name="csrf"]'));
+        if(!csrfInputs) return;
+        
+        csrfInputs.forEach(input => {
+            input.setAttribute('value', csrf);
+        });
     }
 }


### PR DESCRIPTION
Closes #66.

This fix ended up not being specific to pagination. After every fragment swap, the fragment loader updates the URL as well as the CSRF values on the page.