### PR TITLE
add sizes to ico link so chrome will prefer svg

### DIFF
--- a/protected/templates/partials/header.php
+++ b/protected/templates/partials/header.php
@@ -7,7 +7,7 @@
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title><?php echo $SITE_NAME; ?> - <?php echo $v_page_title; ?></title>
 	<link rel="stylesheet" href="<?php echo $SITE_URL; ?>/dist/app.css">
-	<link rel="icon" href="<?php echo $SITE_URL; ?>/favicon.ico">
+	<link rel="icon" sizes="16x16" href="<?php echo $SITE_URL; ?>/favicon.ico">
 	<link rel="icon" href="<?php echo $SITE_URL; ?>/assets/images/favicon.svg" type="image/svg+xml">
 	<link rel="apple-touch-icon" sizes="180x180" href="<?php echo $SITE_URL; ?>/apple-touch-icon.png">
 	<link rel="manifest" href="<?php echo $SITE_URL; ?>/site.webmanifest">


### PR DESCRIPTION
Closes #108.

Turns out all it took was to specify that the ICO version of the icon is intended for 16x16 usage. I guess that forces Chrome to look for a higher resolution icon.

For reference: https://stackoverflow.com/a/64331293/7977844