### PR TITLE
Edit log screen time inputs should accept non zero padded input

### DIFF
--- a/.nova/Configuration.json
+++ b/.nova/Configuration.json
@@ -1,0 +1,4 @@
+{
+  "apexskier.typescript.config.isEnabledForJavascript" : "Disable",
+  "prettier.format-on-save.ignore-without-config" : "Enable"
+}

--- a/protected/src/classes/Utils.php
+++ b/protected/src/classes/Utils.php
@@ -108,7 +108,7 @@ class Utils {
 			// Year must be 4 characters
 			if($i === 0 && iconv_strlen($unit) !== 4) return false;
 			// All other units must be 2 characters
-			if(iconv_strlen($unit) > 2) return false;
+			if($i !== 0 && iconv_strlen($unit) > 2) return false;
 			// Left-pad strings that are too short
 			if($i !== 0) {
 				$unit = str_pad($unit, 2, '0', STR_PAD_LEFT);

--- a/protected/src/classes/Utils.php
+++ b/protected/src/classes/Utils.php
@@ -108,6 +108,8 @@ class Utils {
 			// Year must be 4 characters
 			if($i === 0 && iconv_strlen($unit) !== 4) return false;
 			// All other units must be 2 characters
+			if(iconv_strlen($unit) > 2) return false;
+			// Left-pad strings that are too short
 			if($i !== 0) {
 				$unit = str_pad($unit, 2, '0', STR_PAD_LEFT);
 			}

--- a/protected/src/classes/Utils.php
+++ b/protected/src/classes/Utils.php
@@ -108,7 +108,9 @@ class Utils {
 			// Year must be 4 characters
 			if($i === 0 && iconv_strlen($unit) !== 4) return false;
 			// All other units must be 2 characters
-			if($i !== 0 && iconv_strlen($unit) !== 2) return false;
+			if($i !== 0) {
+				$unit = str_pad($unit, 2, '0', STR_PAD_LEFT);
+			}
 	
 			if($i < 2) $unchunked .= $unit . '-';
 			if($i === 2) $unchunked .= $unit . ' ';


### PR DESCRIPTION
Closes #113. This PR improves the user experience of the Edit Log screen by left-padding two-digit date and time values with zeroes when needed.