### PR TITLE
added polling on the timer form to check server for changes

### DIFF
--- a/protected/templates/partials/timer.php
+++ b/protected/templates/partials/timer.php
@@ -111,7 +111,7 @@
 	<?php endif; ?>
 
 	<?php if ($v_current_log): ?>
-	<div>
+	<div data-log-id="<?php echo $v_current_log['id']; ?>">
 		<p data-timer-elapsed="<?php echo $v_current_log_diff; ?>">
 			<span data-timer-elapsed-display>
 				<?php echo $v_current_log_diff; ?>

--- a/public/assets/js/ajax.js
+++ b/public/assets/js/ajax.js
@@ -108,3 +108,41 @@ async function bodySwapWithUrl(url, config = undefined) {
     console.error(err);
   }
 }
+
+/**
+ * Performs a body swap using the passed-in HTML.
+ * 
+ * @param {string} html 
+ */
+export function bodySwapWithHtml(html) {
+  // body swap
+  $('html').html(html);
+
+  // emit an event to signal body swap complete
+  $(window).trigger('postbodyswap');
+}
+
+/**
+ * Given a URL, performs a fetch request and updates all CSRF tokens. Returns
+ * the textual response of the fetch request.
+ *
+ * @param {string} url the url to fetch
+ * @returns the text of the requested url's response
+ */
+export async function getUrl(url) {
+  try {
+    // get the response as text
+    const resp = await fetch(url);
+    const text = await resp.text();
+
+    // get the csrf token
+    const csrf = $(text).find('[name=csrf]').val();
+    // replace all instances with the new csrf token
+    $('[name=csrf]').val(csrf);
+
+    // return the text response
+    return text;
+  } catch (err) {
+    console.error(err);
+  }
+}


### PR DESCRIPTION
Closes #119.

This PR adds polling to the timer form (every 10 seconds) to check the server for changes in state. This is mainly to prevent the timer from showing an incorrect state for a prolonged period of time.

Personally, this usually happens if I start working on my desktop, then move to my laptop where I eventually stop my timer. When I return to the desktop, I will see a timer that is still running. This feature stops that situation from happening (well, for no longer than 10 seconds, anyway).

It embeds the ID of the current log (if it exists) inside a data attribute on the page. Every 10 seconds, the form makes a request for `/dashboard` and checks to see if the log ID in the new page is still the same.

I added a new helper function for making `GET` requests to a URL. It automatically grabs the new CSRF token and replaces all instances of it on the page. Then it returns the text response of the requested page.

## Demo

https://user-images.githubusercontent.com/801425/129515406-edf806ad-a2b1-4460-a802-0c77b3f7368b.mp4