### PR TITLE
Body swap and timer-on icon fixes

### DIFF
--- a/protected/templates/partials/footer.php
+++ b/protected/templates/partials/footer.php
@@ -1,3 +1,4 @@
+</div> <!-- /.ajax-wrapper -->
 <script src="/dist/app.js"></script>
 </body>
 </html>

--- a/protected/templates/partials/header.php
+++ b/protected/templates/partials/header.php
@@ -16,6 +16,8 @@
 </head>
 <body class="my-5">
 
+<div class="ajax-wrapper">
+
 <?php if(in_array(
 	'csrf_error', $v_errors_element_ids ? : array()
 )) : ?>

--- a/public/assets/js/ajax.js
+++ b/public/assets/js/ajax.js
@@ -100,23 +100,24 @@ async function bodySwapWithUrl(url, config = undefined) {
     // get text of response
     const text = await resp.text();
     // body swap
-    $('html').html(text);
-
-    // emit an event to signal body swap complete
-    $(window).trigger('postbodyswap');
+    bodySwapWithHtml(text);
   } catch (err) {
     console.error(err);
   }
 }
 
 /**
- * Performs a body swap using the passed-in HTML.
- * 
+ * Performs a "body" swap using the passed-in HTML. It isn't actually all the
+ * content of the body tag, but rather everything inside the .ajax-wrapper
+ * <div>.
+ *
  * @param {string} html 
  */
 export function bodySwapWithHtml(html) {
+  // get the contents of the new page
+  const $wrapper = $(`<div>${html}</div>`).find('.ajax-wrapper');
   // body swap
-  $('html').html(html);
+  $('.ajax-wrapper').html($wrapper.html());
 
   // emit an event to signal body swap complete
   $(window).trigger('postbodyswap');

--- a/public/assets/js/timer.js
+++ b/public/assets/js/timer.js
@@ -56,6 +56,10 @@ export function initTimer() {
     return;
   }
 
+  // turn off the timer icon if needed
+  const $favicon = $('[rel=icon][type="image/svg+xml"]');
+  $favicon.attr('href', '/assets/images/favicon.svg');
+
   // initialize form state
   const state = new FormData($timerForm[0]);
 

--- a/public/assets/js/timer.js
+++ b/public/assets/js/timer.js
@@ -115,6 +115,18 @@ async function checkServerForTimerStateChange() {
     if (currentLogId !== newLogId) {
       resetUiState();
       bodySwapWithHtml(text);
+      return;
+    }
+
+    setFormType();
+
+    // weird hack required by firefox in order to keep the "on" icon from
+    // disappearing. if timer is running and thus we want the "on" icon, we need
+    // to switch the icon off and then back on again. go figure.
+    if (formType === FormTypes.STOP_FORM) {
+      const $favicon = $('[rel=icon][type="image/svg+xml"]');
+      $favicon.attr('href', '/assets/images/favicon.svg');
+      $favicon.attr('href', '/assets/images/favicon-on.svg');
     }
   } catch (err) {
     console.error(err)


### PR DESCRIPTION
Closes #132 

This PR fixes the issue where Firefox turns off the timer-on icon after polling for timer state change. The solution was really dumb—turn the icon off and then turn it back on.

I also adjusted the body swap code. Previously, I was swapping out the HTML wholesale. I believe this is problematic, probably in a number of ways, but for sure when it comes to screen tearing/flash of unstyled content (FOUC). I added a wrapper `<div>` around everything. It has a class of `ajax-wrapper`. Now when I do a body swap, I just take the contents of that `<div>` and swap those out.

I didn't bother trying to update the page title in the `<head>` because we don't really change the title on any of the pages where we are using AJAX. I don't feel like solving a problem we don't have yet and leaving the `<head>` as it is makes things simpler.

I poked around and everything seems good to go, but it's hard to do thorough testing on local since you aren't using it like you would the real timer. I figure we deploy this and solve any problems we run into after that—which hopefully will be none.