### PR TITLE
polling for timer status now works correctly on the teams dashboard

### DIFF
--- a/public/assets/js/timer.js
+++ b/public/assets/js/timer.js
@@ -113,7 +113,7 @@ function resetUiState() {
 async function checkServerForTimerStateChange() {
   try {
     const currentLogId = $('[data-log-id]').data('log-id') || null;
-    const text = await getUrl('/dashboard');
+    const text = await getUrl(window.location);
     const newLogId = $(text).find('[data-log-id]').data('log-id') || null;
 
     if (currentLogId !== newLogId) {


### PR DESCRIPTION
Closes #134.

When polling for the current timer status, the code now uses `window.location` instead of a hardcoded `/dashboard` value.